### PR TITLE
Fix power-up tile selection bounds check

### DIFF
--- a/src/utils/powerUps.ts
+++ b/src/utils/powerUps.ts
@@ -113,11 +113,19 @@ export const startPowerUpSelection = (type: 'swap' | 'delete' | 'freeze', powerU
   }
 };
 
-export const canPickTile = (row: number, col: number, grid: any[][], selectingPowerUp: SelectingPowerUp, frozenTiles: { [tileId: string]: number }): boolean => {
-  if (!selectingPowerUp || !grid[row][col]) return false;
-  
-  const tile = grid[row][col];
-  
+export const canPickTile = (
+  row: number,
+  col: number,
+  grid: any[][],
+  selectingPowerUp: SelectingPowerUp,
+  frozenTiles: { [tileId: string]: number }
+): boolean => {
+  if (!selectingPowerUp) return false;
+
+  // Safely access the grid to avoid out-of-bounds errors
+  const tile = grid[row]?.[col];
+  if (!tile) return false;
+
   // Swap: can't select frozen tiles (they can't be moved)
   if (selectingPowerUp.type === 'swap' && isTileFrozen(tile.id, frozenTiles)) {
     return false;


### PR DESCRIPTION
## Summary
- Safely check grid indices when selecting tiles for power-ups
- Avoid runtime errors by validating tile existence before access

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a85842b6e0832094beec49eef4403f